### PR TITLE
Angular CLI glitch

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "4.1.2",
-    "@angular/cli": "^1.1.0-rc.0",
+    "@angular/cli": "1.1.2",
     "@angular/common": "4.1.2",
     "@angular/compiler": "4.1.2",
     "@angular/compiler-cli": "4.1.2",

--- a/src/app/purchase/offer/offer.model.ts
+++ b/src/app/purchase/offer/offer.model.ts
@@ -1,3 +1,5 @@
 import { Offer as OfferI } from '../../../../d/kundeunivers';
 
-export class Offer implements OfferI {}
+export class Offer implements OfferI {
+  [key: string]: any;
+}


### PR DESCRIPTION
A class must re-implement all the properties of the interface it implements.

This is a bug in angular-cli and this PR is just adding a workaround.