### PR TITLE
Changed urls in Router to hashes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "hapi": "16.1.1",
     "hapi-auth-jwt2": "7.2.4",
     "hawk": "6.0.1",
+    "http-server": "0.10.0",
     "inert": "4.2.0",
     "jsonwebtoken": "7.4.0",
     "lodash": "4.17.4",

--- a/src/app/core/routes.module.ts
+++ b/src/app/core/routes.module.ts
@@ -50,7 +50,7 @@ const routes: Routes = [
   imports: [
     LoginModule,
     RootModule,
-    RouterModule.forRoot(routes),
+    RouterModule.forRoot(routes, {useHash: true}),
     SharedModule
   ],
   providers: [


### PR DESCRIPTION
On a standalone server we would need additional configuration to route all urls to index. Currently, the easier solution is to use hash urls instead of normal ones.